### PR TITLE
Modified to support certain hikvision NVR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,18 @@ Run using `java -jar hikvision-download-assistant.jar <options>`.
 ### Usage statement
 
 ```
-Usage: java -jar hikvision-download-assistant.jar [-hqV] [-d=<tableDelimiter>] [-f=<fromTime>] [-o=<outputFormat>] [-p=<outputPassword>] [-t=<toTime>] [-u=<outputUsername>] HOST USERNAME PASSWORD
+Usage: java -jar hikvision-download-assistant.jar [-hlqV] [-c=<channelId>] [-d=<tableDelimiter>] [-f=<fromTime>] [-o=<outputFormat>] [-p=<outputPassword>] [-t=<toTime>] [-u=<outputUsername>] HOST USERNAME PASSWORD
       HOST                 Connect to this host or IP address to perform search.
       USERNAME             Use this username when connecting to perform search.
       PASSWORD             Use this password when connecting to perform search.
+  -c, --channel-id=<channelId>
+                           The channel id. Defaults to '101'.
   -d, --table-delimiter=<tableDelimiter>
                            The column delimiter for table output. Defaults to '|'.
   -f, --from-time=<fromTime>
                            Search starting from this time, entered using English natural language. Defaults to '24 hours ago'.
   -h, --help               Show this help message and exit.
+  -l, --legacy             The legacy mode for timezone process.
   -o, --output=<outputFormat>
                            Output format. Can be 'table' or 'json'. Defaults to 'table'.
   -p, --output-password=<outputPassword>

--- a/src/main/java/rr/hikvisiondownloadassistant/DateConverter.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/DateConverter.java
@@ -4,6 +4,9 @@ package rr.hikvisiondownloadassistant;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -35,6 +38,14 @@ public class DateConverter {
         try {
             return apiDateFormat.parse(timeString);
         } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String apiStringToNextSecond(String timeString) {
+        try {
+            return Instant.parse(timeString).plus(1, ChronoUnit.SECONDS).toString();
+        } catch (DateTimeParseException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/rr/hikvisiondownloadassistant/DateConverter.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/DateConverter.java
@@ -8,6 +8,8 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class DateConverter {
+    private static boolean legacyMode = false;
+    private static TimeZone defaultTimezone;
 
     private static final SimpleDateFormat apiDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
     private static final SimpleDateFormat localDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
@@ -15,7 +17,18 @@ public class DateConverter {
     private static final SimpleDateFormat localHumanDateFormat = new SimpleDateFormat("EEEE MMM d, yyyy 'at' h:mm:ss aaa z");
 
     static {
+        defaultTimezone = apiDateFormat.getTimeZone();
         apiDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+    }
+
+    public static void setLegacyTimezoneMode(boolean legacy) {
+        legacyMode = legacy;
+        if (legacyMode) {
+            apiDateFormat.setTimeZone(defaultTimezone);
+        }
+        else {
+            apiDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        }
     }
 
     public static Date apiStringToDate(String timeString) {

--- a/src/main/java/rr/hikvisiondownloadassistant/DigestAuth.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/DigestAuth.java
@@ -51,7 +51,7 @@ public class DigestAuth {
 
         String[] authenticateFields = authChallenge.substring("Digest ".length()).replace("\"", "").split(", ");
         Map<String, String> authenticateFieldsMap = Arrays.stream(authenticateFields)
-                .map(s -> s.split("="))
+                .map(s -> s.split("=", 2))
                 .collect(Collectors.toMap(a -> a[0], a -> a[1]));
 
         String realm = authenticateFieldsMap.get("realm");

--- a/src/main/java/rr/hikvisiondownloadassistant/IsapiRestClient.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/IsapiRestClient.java
@@ -21,6 +21,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
+import static rr.hikvisiondownloadassistant.DateConverter.apiStringToNextSecond;
+
 @Getter
 @RequiredArgsConstructor
 public class IsapiRestClient {
@@ -54,7 +56,7 @@ public class IsapiRestClient {
             if (searchResult.isResponseStatus() && searchResult.getResponseStatusStrg().equalsIgnoreCase("more")) {
                 if (searchResult.getVersion().equals("1.0")) {
                     // XXX: version 1.0 seems does not support searchResultPosition well, we need update fromDate
-                    fromDate = matches.get(matches.size() - 1).getTimeSpan().getEndTime();
+                    fromDate = apiStringToNextSecond(matches.get(matches.size() - 1).getTimeSpan().getEndTime());
                 }
                 else {
                     searchResultPosition += maxResults;

--- a/src/main/java/rr/hikvisiondownloadassistant/Model.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/Model.java
@@ -12,9 +12,6 @@ import java.util.List;
 
 public class Model {
 
-    public static final int VIDEOS_TRACK_ID = 101;
-    public static final int PHOTOS_TRACK_ID = 103;
-
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/rr/hikvisiondownloadassistant/Options.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/Options.java
@@ -42,6 +42,19 @@ public class Options {
     private String password;
 
     @Option(
+            names = {"-c", "--channel-id"},
+            defaultValue = "101",
+            description = "The channel id. Defaults to '${DEFAULT-VALUE}'."
+    )
+    private int channelId;
+
+    @Option(
+            names = {"-l", "--legacy"},
+            description = "Process timezone in legacy mode for some NVRs."
+    )
+    private boolean legacyTimeProcess = false;
+
+    @Option(
             names = {"-f", "--from-time"},
             defaultValue = "24 hours ago",
             description = "Search starting from this time, entered using English natural language. Defaults to '${DEFAULT-VALUE}'."

--- a/src/main/java/rr/hikvisiondownloadassistant/OutputFormatter.java
+++ b/src/main/java/rr/hikvisiondownloadassistant/OutputFormatter.java
@@ -25,6 +25,16 @@ public class OutputFormatter {
         VIDEO
     }
 
+    private MediaType mediaTypeFromContentType(String contentType) {
+        if (contentType.toLowerCase().equals("video")) {
+            return MediaType.VIDEO;
+        }
+        if (contentType.toLowerCase().equals("photo")) {
+            return MediaType.PHOTO;
+        }
+        throw new Error("Non-supported file contentType: " + contentType);
+    }
+
     @Builder
     @Getter
     private static class Metadata {
@@ -43,12 +53,10 @@ public class OutputFormatter {
     }
 
     private final Options options;
-    private final List<SearchMatchItem> videos;
-    private final List<SearchMatchItem> photos;
+    private final List<SearchMatchItem> results;
 
     public void printResults() {
-        List<OutputRow> rows = convertToOutputRows(MediaType.VIDEO, videos);
-        rows.addAll(convertToOutputRows(MediaType.PHOTO, photos));
+        List<OutputRow> rows = convertToOutputRows(results);
 
         rows.sort(Comparator.comparing(OutputRow::getStartTime));
 
@@ -93,10 +101,10 @@ public class OutputFormatter {
                 .forEach(row -> System.out.println(String.join(tableColumnDelimiter, row)));
     }
 
-    private List<OutputRow> convertToOutputRows(MediaType mediaType, List<SearchMatchItem> items) {
+    private List<OutputRow> convertToOutputRows(List<SearchMatchItem> items) {
         return items.stream().map(item -> new OutputRow(
                         item,
-                        mediaType,
+                        mediaTypeFromContentType(item.getMediaSegmentDescriptor().getContentType()),
                         apiStringToDate(item.getTimeSpan().getStartTime()),
                         apiStringToDate(item.getTimeSpan().getEndTime())
                 )


### PR DESCRIPTION
- The searchId UUID is formatted correctly.
- Fix the digital auth header parsing failure due to key with empty value.
- Query media files by channel id, default for video 101. So for channel 2 of NVR, videos channel is 201.
- Support old NVR ISAPI v1.0 query (timezone fix, and load more by adjust fromTime internally).

PHOTO channel is not tested due lack of devices, so please double check whether it still works.